### PR TITLE
Add design type to KiCad meta info files

### DIFF
--- a/design-rules/kicad/AISLER-2Layer-Complex/meta/info.html
+++ b/design-rules/kicad/AISLER-2Layer-Complex/meta/info.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
-	<title>AISLER</title>
+	<title>AISLER Complex 2 Layer</title>
 </head>
 <body>
-	<h2>AISLER - 2 Layer</h2>
-	<p> This creates a default board with AISLER's rules for 2 Layer designs.</p> 
+	<h2>AISLER - 2 Layer - Complex</h2>
+	<p> This creates a default board with AISLER's rules for complex 2 Layer designs.</p>
 	<p>It includes two net classes: 
 	<ul>
 	<li>Min, which represents the bare minimum allowed</li> 

--- a/design-rules/kicad/AISLER-2Layer-Simple/meta/info.html
+++ b/design-rules/kicad/AISLER-2Layer-Simple/meta/info.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 	<meta HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
-	<title>AISLER</title>
+	<title>AISLER Simple 2 Layer</title>
 </head>
 <body>
-	<h2>AISLER - 2 Layer</h2>
-	<p> This creates a default board with AISLER's rules for 2 Layer designs.</p> 
+	<h2>AISLER - 2 Layer - Simple</h2>
+	<p> This creates a default board with AISLER's rules for simple 2 Layer designs.</p>
 	<p>It includes two net classes: 
 	<ul>
 	<li>Min, which represents the bare minimum allowed</li> 

--- a/design-rules/kicad/AISLER-4Layer-Complex/meta/info.html
+++ b/design-rules/kicad/AISLER-4Layer-Complex/meta/info.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
-	<title>AISLER</title>
+	<title>AISLER 4 Layer</title>
 </head>
 <body>
 	<h2>AISLER - 4 Layer</h2>


### PR DESCRIPTION
It is hard to distinguish the current design projects if they are used as KiCad templates. Expanding the title and descriptions makes it easy to select the right design.

Screenshot after applying this change:
![aisler-doc](https://user-images.githubusercontent.com/61306/182034185-d3ccc493-3fc3-43fc-a58f-5fc1544d994f.png)
