### PR TITLE
[KiCad] 2L Simple: Via diameter in default netclass should be 0.7mm, not 0.6mm

### DIFF
--- a/kicad/aisler-2-layer-simple-drc/aisler-2-layer-simple-drc.kicad_pro
+++ b/kicad/aisler-2-layer-simple-drc/aisler-2-layer-simple-drc.kicad_pro
@@ -285,7 +285,7 @@
         "pcb_color": "rgba(0, 0, 0, 0.000)",
         "schematic_color": "rgba(0, 0, 0, 0.000)",
         "track_width": 0.2,
-        "via_diameter": 0.6,
+        "via_diameter": 0.7,
         "via_drill": 0.3,
         "wire_width": 6
       }


### PR DESCRIPTION
2L simple design rules for vias are:
- 0.3mm drill
- 0.2mm annular ring
- 0.7mm via (0.3mm + 2*0.2mm)

These values are correct in the Design Rules / Constraints and in the Pre-defined Sizes.  
However, the **Default Netclass** has a **wrong Via Size** defined: **0.6mm instead of 0.7mm**:  
![vias](https://github.com/user-attachments/assets/1e369ded-6da9-4373-84d4-3485e55aa224)  
This violates the Design Rules Constraints, but apparently in KiCad 8 this did not trigger DRC Errors for vias made with this netclass settings(?!) - KiCad 9 does throw DRC Errors for such vias (as one would expect).