### PR TITLE
fix: check for a sm margin of 0 and the default field state "null"

### DIFF
--- a/kicad/aisler-4-layer-hd-drc/aisler-4-layer-hd-drc.kicad_dru
+++ b/kicad/aisler-4-layer-hd-drc/aisler-4-layer-hd-drc.kicad_dru
@@ -33,7 +33,7 @@
 # We do this on our own, please keep the soldermask margin set to 0. 
  
 (rule "Disallow solder mask margin overrides"
-    (constraint assertion "A.Soldermask_Margin_Override == 0mm")
+    (constraint assertion "A.Soldermask_Margin_Override == 0mm || A.Soldermask_Margin_Override == null")
     (condition "A.Type == 'Pad'"))
 
 #----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Using your design rules in KiCAD 9 results in most pads getting an error about solder mask margin overrides when running the DRC, see #22 . This PR includes an `or` operation that checks for an empty field (default and denoted by `null`). This means it is also backwards compatible.