### PR TITLE
kicad: also fix solder mask margin overrides assertion for 2-layer templates

### DIFF
--- a/kicad/aisler-2-layer-hd-drc/aisler-2-layer-hd-drc.kicad_dru
+++ b/kicad/aisler-2-layer-hd-drc/aisler-2-layer-hd-drc.kicad_dru
@@ -33,7 +33,7 @@
 # We do this on our own, please keep the soldermask margin set to 0. 
  
 (rule "Disallow solder mask margin overrides"
-    (constraint assertion "A.Soldermask_Margin_Override == 0mm")
+    (constraint assertion "A.Soldermask_Margin_Override == 0mm || A.Soldermask_Margin_Override == null")
     (condition "A.Type == 'Pad'"))
 
 #----------------------------------------------------------------------------------------------------

--- a/kicad/aisler-2-layer-simple-drc/aisler-2-layer-simple-drc.kicad_dru
+++ b/kicad/aisler-2-layer-simple-drc/aisler-2-layer-simple-drc.kicad_dru
@@ -33,7 +33,7 @@
 # We do this on our own, please keep the soldermask margin set to 0. 
  
 (rule "Disallow solder mask margin overrides"
-    (constraint assertion "A.Soldermask_Margin_Override == 0mm")
+    (constraint assertion "A.Soldermask_Margin_Override == 0mm || A.Soldermask_Margin_Override == null")
     (condition "A.Type == 'Pad'"))
 
 #----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

https://github.com/AislerHQ/aisler-support/pull/28 fixed https://github.com/AislerHQ/aisler-support/issues/22 ("Disallow solder mask margin overrides rule does not work in Kicad 9") only for the 4-Layer template. The same issue applies to the two 2-Layer templates which are fixed by this patch.

Best,
Simon